### PR TITLE
Whitelist more channels, make emoji reaction marquee

### DIFF
--- a/channel-whitelist.js
+++ b/channel-whitelist.js
@@ -1,5 +1,5 @@
 const channelWhitelist = id => ({
-  'C0159TSJVH8': 'what-is-my-channel-id',
+  'C0159TSJVH8': 'what-is-my-slack-id',
   'C0266FRGV': 'lounge',
   'C0P5NE354': 'bot-spam',
   'C01EZ2MNPTQ': 'katabatic-wind',
@@ -12,5 +12,8 @@ const channelWhitelist = id => ({
   'CDJV1CXC2': 'dogs',
   'C1C3K2RQV': 'design',
   'C01D7AHKMPF': 'community',
-  'C0178M084FL': 'crypto'
+  'C0178M084FL': 'crypto',
+  'C01TW2CAK55': 'whack-a-mole',
+  'C020LT3UCBW': 'bot-spam-for-deer',
+  'C02HSS9Q3D5': 'boston-for-deer'
 }[id])

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
         bottom: 0;
         left: 0;
         padding: 3px;
+        width: 100vw;
       }
       .recent-emoji > * {
         font-size: 1.5em;
@@ -243,7 +244,7 @@
   <body>
     <iframe class="livestream"></iframe>
     <div class="unregistered-hypercam-2">Unregistered HyperCam 2</div>
-    <div class="recent-emoji"></div>
+    <marquee class="recent-emoji"></marquee>
     <div id="loaded-at"></div>
     <img
       id="flag-logo"


### PR DESCRIPTION
This PR makes the emoji reaction box a marquee that moves across the screen and whitelists channels that have a lot of emoji reactions like #bot-spam-for-deer #boston-for-deer and #whack-a-mole.

The marquee makes it look something like this: 

https://user-images.githubusercontent.com/72365100/146662230-e2e288a8-cb73-4715-8e12-029355b659c1.mov


